### PR TITLE
データが空の時の画面を実装

### DIFF
--- a/NextSunnyDay.xcodeproj/project.pbxproj
+++ b/NextSunnyDay.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		919EA78625304DAB008BC359 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 919EA78525304DAB008BC359 /* RealmSwift */; };
 		919EA78B253051F1008BC359 /* WeeklyForecastEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919EA78A253051F1008BC359 /* WeeklyForecastEntity.swift */; };
 		91A2960F2534369F00CCC7B2 /* ViewModelObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2960E2534369F00CCC7B2 /* ViewModelObject.swift */; };
+		91A2961725344DB700CCC7B2 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2961625344DB700CCC7B2 /* HomeViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +67,7 @@
 		917E416B2525CE6C00D77C3F /* WeatherFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherFetcher.swift; sourceTree = "<group>"; };
 		919EA78A253051F1008BC359 /* WeeklyForecastEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyForecastEntity.swift; sourceTree = "<group>"; };
 		91A2960E2534369F00CCC7B2 /* ViewModelObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelObject.swift; sourceTree = "<group>"; };
+		91A2961625344DB700CCC7B2 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -213,6 +215,7 @@
 		915F516D2521882F00B4E384 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				91A2961625344DB700CCC7B2 /* HomeViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -429,6 +432,7 @@
 				917E416C2525CE6C00D77C3F /* WeatherFetcher.swift in Sources */,
 				917E414E2525B13F00D77C3F /* WeeklyForecastResponse.swift in Sources */,
 				915F513B2521763500B4E384 /* HomeView.swift in Sources */,
+				91A2961725344DB700CCC7B2 /* HomeViewModel.swift in Sources */,
 				91500CCF2533404300D5F47D /* R.generated.swift in Sources */,
 				915F51392521763500B4E384 /* NextSunnyDayApp.swift in Sources */,
 				917E41642525CA5D00D77C3F /* AccessTokens.swift in Sources */,

--- a/NextSunnyDay.xcodeproj/project.pbxproj
+++ b/NextSunnyDay.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		919EA78425304DAB008BC359 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 919EA78325304DAB008BC359 /* Realm */; };
 		919EA78625304DAB008BC359 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 919EA78525304DAB008BC359 /* RealmSwift */; };
 		919EA78B253051F1008BC359 /* WeeklyForecastEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919EA78A253051F1008BC359 /* WeeklyForecastEntity.swift */; };
+		91A2960F2534369F00CCC7B2 /* ViewModelObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2960E2534369F00CCC7B2 /* ViewModelObject.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,6 +65,7 @@
 		917E41632525CA5D00D77C3F /* AccessTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokens.swift; sourceTree = "<group>"; };
 		917E416B2525CE6C00D77C3F /* WeatherFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherFetcher.swift; sourceTree = "<group>"; };
 		919EA78A253051F1008BC359 /* WeeklyForecastEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyForecastEntity.swift; sourceTree = "<group>"; };
+		91A2960E2534369F00CCC7B2 /* ViewModelObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelObject.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -203,6 +205,7 @@
 		915F516C2521882800B4E384 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
+				91A2960E2534369F00CCC7B2 /* ViewModelObject.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -429,6 +432,7 @@
 				91500CCF2533404300D5F47D /* R.generated.swift in Sources */,
 				915F51392521763500B4E384 /* NextSunnyDayApp.swift in Sources */,
 				917E41642525CA5D00D77C3F /* AccessTokens.swift in Sources */,
+				91A2960F2534369F00CCC7B2 /* ViewModelObject.swift in Sources */,
 				917E415F2525C85600D77C3F /* WeatherError.swift in Sources */,
 				919EA78B253051F1008BC359 /* WeeklyForecastEntity.swift in Sources */,
 			);

--- a/NextSunnyDay.xcodeproj/project.pbxproj
+++ b/NextSunnyDay.xcodeproj/project.pbxproj
@@ -600,7 +600,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.naipaka.NextSunnyDay;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -622,7 +622,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.naipaka.NextSunnyDay;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/NextSunnyDay/Info.plist
+++ b/NextSunnyDay/Info.plist
@@ -36,8 +36,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/NextSunnyDay/NextSunnyDayApp.swift
+++ b/NextSunnyDay/NextSunnyDayApp.swift
@@ -11,7 +11,8 @@ import SwiftUI
 struct NextSunnyDayApp: App {
     var body: some Scene {
         WindowGroup {
-            HomeView()
+            let viewModel = HomeViewModel()
+            HomeView(viewModel: viewModel)
         }
     }
 }

--- a/NextSunnyDay/Protocol/ViewModelObject.swift
+++ b/NextSunnyDay/Protocol/ViewModelObject.swift
@@ -1,0 +1,37 @@
+//
+//  ViewModelObject.swift
+//  NextSunnyDay
+//
+//  Created by rMac on 2020/10/12.
+//
+
+import Combine
+
+// MARK: - ViewModelObject
+protocol ViewModelObject: ObservableObject {
+    associatedtype Input: InputObject
+    associatedtype Binding: BindingObject
+    associatedtype Output: OutputObject
+
+    var input: Input { get }
+    var binding: Binding { get }
+    var output: Output { get }
+}
+
+extension ViewModelObject where Binding.ObjectWillChangePublisher == ObservableObjectPublisher, Output.ObjectWillChangePublisher == ObservableObjectPublisher {
+    var objectWillChange: AnyPublisher<Void, Never> {
+        Publishers.Merge(binding.objectWillChange, output.objectWillChange).eraseToAnyPublisher()
+    }
+}
+
+// MARK: - InputObject
+protocol InputObject: AnyObject {
+}
+
+// MARK: - BindingObject
+protocol BindingObject: ObservableObject {
+}
+
+// MARK: - OutputObject
+protocol OutputObject: ObservableObject {
+}

--- a/NextSunnyDay/Resourece/strings/Home.strings
+++ b/NextSunnyDay/Resourece/strings/Home.strings
@@ -7,3 +7,4 @@
 */
 
 "navigationBarTitle" = "次の晴れの日☀️";
+"emptyText" = "右上の設定ボタンから\n地域を設定しましょう";

--- a/NextSunnyDay/Resourece/strings/SystemName.strings
+++ b/NextSunnyDay/Resourece/strings/SystemName.strings
@@ -7,3 +7,4 @@
 */
 
 "gearshape.fill" = "gearshape.fill";
+"sun.min.fill" = "sun.min.fill";

--- a/NextSunnyDay/View/HomeView.swift
+++ b/NextSunnyDay/View/HomeView.swift
@@ -27,6 +27,18 @@ private extension HomeView {
                 .foregroundColor(.gray)
         })
     }
+
+    var emptyView: some View {
+        VStack {
+            Image(systemName: R.string.systemName.sunMinFill())
+                .resizable()
+                .frame(width: 160, height: 160, alignment: .center)
+                .padding()
+            Text(R.string.home.emptyText())
+            Spacer().frame(height: 60)
+        }
+        .foregroundColor(.gray)
+    }
 }
 
 struct HomeView_Previews: PreviewProvider {

--- a/NextSunnyDay/View/HomeView.swift
+++ b/NextSunnyDay/View/HomeView.swift
@@ -7,12 +7,22 @@
 
 import SwiftUI
 
-struct HomeView: View {
+struct HomeView<T>: View where T: HomeViewModelObject {
+    @ObservedObject private var viewModel: T
+
+    init(viewModel: T) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
         NavigationView {
             ZStack {
                 Color(.systemGroupedBackground).edgesIgnoringSafeArea(.all)
-                VStack {}
+                if viewModel.output.dataSource.isEmpty {
+                    emptyView
+                } else {
+                    // TODO: NextSunnyDayView and WeeklyForecastView
+                }
             }
             .navigationBarTitle(R.string.home.navigationBarTitle())
             .navigationBarItems(trailing: toSettingViewButton)
@@ -45,6 +55,39 @@ private extension HomeView {
 
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
-        HomeView()
+        Group {
+            HomeView(viewModel: MockViewModel(dataSource: []))
+            HomeView(viewModel: MockViewModel(dataSource: [Daily()]))
+        }
+    }
+}
+
+extension HomeView_Previews {
+    final class MockViewModel: HomeViewModelObject {
+        final class Input: HomeViewModelInputObject {}
+
+        final class Binding: HomeViewModelBindingObject {}
+
+        final class Output: HomeViewModelOutputObject {
+            @Published var dataSource: [Daily] = []
+        }
+
+        var input: Input
+
+        var binding: Binding
+
+        var output: Output
+
+        init(dataSource: [Daily]) {
+            let input = Input()
+            let binding = Binding()
+            let output = Output()
+
+            output.dataSource = dataSource
+
+            self.input = input
+            self.binding = binding
+            self.output = output
+        }
     }
 }

--- a/NextSunnyDay/View/HomeView.swift
+++ b/NextSunnyDay/View/HomeView.swift
@@ -24,6 +24,8 @@ private extension HomeView {
     var toSettingViewButton: some View {
         Button(action: {}, label: {
             Image(systemName: R.string.systemName.gearshapeFill())
+                .resizable()
+                .frame(width: 20, height: 20, alignment: .center)
                 .foregroundColor(.gray)
         })
     }

--- a/NextSunnyDay/ViewModel/HomeViewModel.swift
+++ b/NextSunnyDay/ViewModel/HomeViewModel.swift
@@ -1,0 +1,55 @@
+//
+//  HomeViewModel.swift
+//  NextSunnyDay
+//
+//  Created by rMac on 2020/10/12.
+//
+
+import Combine
+
+// MARK: - HomeViewModelObject
+protocol HomeViewModelObject: ViewModelObject where Input: HomeViewModelInputObject, Binding: HomeViewModelBindingObject, Output: HomeViewModelOutputObject {
+    var input: Input { get }
+    var binding: Binding { get }
+    var output: Output { get }
+}
+
+// MARK: - HomeViewModelInputObject
+protocol HomeViewModelInputObject: InputObject {
+}
+
+// MARK: - HomeViewModelBindingObject
+protocol HomeViewModelBindingObject: BindingObject {
+}
+
+// MARK: - HomeViewModelOutputObject
+protocol HomeViewModelOutputObject: OutputObject {
+    var dataSource: [Daily] { get }
+}
+
+// MARK: - HomeViewModel
+class HomeViewModel: HomeViewModelObject {
+    final class Input: HomeViewModelInputObject {}
+
+    final class Binding: HomeViewModelBindingObject {}
+
+    final class Output: HomeViewModelOutputObject {
+        @Published var dataSource: [Daily] = []
+    }
+
+    var input: Input
+
+    var binding: Binding
+
+    var output: Output
+
+    init() {
+        let input = Input()
+        let binding = Binding()
+        let output = Output()
+
+        self.input = input
+        self.binding = binding
+        self.output = output
+    }
+}


### PR DESCRIPTION
# Issue
close #7 

# 対応詳細
- 天気情報のデータが空の場合画面を実装
    - View実装
        - dataSourceが空の場合は空の時のViewを返す
        - Preview修正
            - データが空の場合とそうでない場合のPreviewを表示
    - 全てのViewModelに準拠したプロトコル、ViewModelObject作成
    - ViewModel実装
        - dataSourceは空で返す
    - その他微修正