### PR TITLE
構造体とクラスの命名と文字列を微修正

### DIFF
--- a/NextSunnyDay.xcodeproj/project.pbxproj
+++ b/NextSunnyDay.xcodeproj/project.pbxproj
@@ -17,13 +17,13 @@
 		915F51402521763600B4E384 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 915F513F2521763600B4E384 /* Preview Assets.xcassets */; };
 		915F514B2521763600B4E384 /* NextSunnyDayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915F514A2521763600B4E384 /* NextSunnyDayTests.swift */; };
 		915F51562521763600B4E384 /* NextSunnyDayUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915F51552521763600B4E384 /* NextSunnyDayUITests.swift */; };
-		917E414E2525B13F00D77C3F /* WeeklyForecastResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E414D2525B13F00D77C3F /* WeeklyForecastResponse.swift */; };
+		917E414E2525B13F00D77C3F /* DailyWeatherForecastResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E414D2525B13F00D77C3F /* DailyWeatherForecastResponse.swift */; };
 		917E415F2525C85600D77C3F /* WeatherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E415E2525C85600D77C3F /* WeatherError.swift */; };
 		917E41642525CA5D00D77C3F /* AccessTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E41632525CA5D00D77C3F /* AccessTokens.swift */; };
 		917E416C2525CE6C00D77C3F /* WeatherFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E416B2525CE6C00D77C3F /* WeatherFetcher.swift */; };
 		919EA78425304DAB008BC359 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 919EA78325304DAB008BC359 /* Realm */; };
 		919EA78625304DAB008BC359 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 919EA78525304DAB008BC359 /* RealmSwift */; };
-		919EA78B253051F1008BC359 /* WeeklyForecastEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919EA78A253051F1008BC359 /* WeeklyForecastEntity.swift */; };
+		919EA78B253051F1008BC359 /* DailyWeatherForecastEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919EA78A253051F1008BC359 /* DailyWeatherForecastEntity.swift */; };
 		91A2960F2534369F00CCC7B2 /* ViewModelObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2960E2534369F00CCC7B2 /* ViewModelObject.swift */; };
 		91A2961725344DB700CCC7B2 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2961625344DB700CCC7B2 /* HomeViewModel.swift */; };
 /* End PBXBuildFile section */
@@ -61,11 +61,11 @@
 		915F51512521763600B4E384 /* NextSunnyDayUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NextSunnyDayUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		915F51552521763600B4E384 /* NextSunnyDayUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextSunnyDayUITests.swift; sourceTree = "<group>"; };
 		915F51572521763600B4E384 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		917E414D2525B13F00D77C3F /* WeeklyForecastResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyForecastResponse.swift; sourceTree = "<group>"; };
+		917E414D2525B13F00D77C3F /* DailyWeatherForecastResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyWeatherForecastResponse.swift; sourceTree = "<group>"; };
 		917E415E2525C85600D77C3F /* WeatherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherError.swift; sourceTree = "<group>"; };
 		917E41632525CA5D00D77C3F /* AccessTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokens.swift; sourceTree = "<group>"; };
 		917E416B2525CE6C00D77C3F /* WeatherFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherFetcher.swift; sourceTree = "<group>"; };
-		919EA78A253051F1008BC359 /* WeeklyForecastEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyForecastEntity.swift; sourceTree = "<group>"; };
+		919EA78A253051F1008BC359 /* DailyWeatherForecastEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyWeatherForecastEntity.swift; sourceTree = "<group>"; };
 		91A2960E2534369F00CCC7B2 /* ViewModelObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelObject.swift; sourceTree = "<group>"; };
 		91A2961625344DB700CCC7B2 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -231,7 +231,7 @@
 		915F516F2521883F00B4E384 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				919EA78A253051F1008BC359 /* WeeklyForecastEntity.swift */,
+				919EA78A253051F1008BC359 /* DailyWeatherForecastEntity.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -239,7 +239,7 @@
 		917E414C2525B11200D77C3F /* OpenWeatherAPI */ = {
 			isa = PBXGroup;
 			children = (
-				917E414D2525B13F00D77C3F /* WeeklyForecastResponse.swift */,
+				917E414D2525B13F00D77C3F /* DailyWeatherForecastResponse.swift */,
 				917E416B2525CE6C00D77C3F /* WeatherFetcher.swift */,
 				917E415E2525C85600D77C3F /* WeatherError.swift */,
 			);
@@ -430,7 +430,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				917E416C2525CE6C00D77C3F /* WeatherFetcher.swift in Sources */,
-				917E414E2525B13F00D77C3F /* WeeklyForecastResponse.swift in Sources */,
+				917E414E2525B13F00D77C3F /* DailyWeatherForecastResponse.swift in Sources */,
 				915F513B2521763500B4E384 /* HomeView.swift in Sources */,
 				91A2961725344DB700CCC7B2 /* HomeViewModel.swift in Sources */,
 				91500CCF2533404300D5F47D /* R.generated.swift in Sources */,
@@ -438,7 +438,7 @@
 				917E41642525CA5D00D77C3F /* AccessTokens.swift in Sources */,
 				91A2960F2534369F00CCC7B2 /* ViewModelObject.swift in Sources */,
 				917E415F2525C85600D77C3F /* WeatherError.swift in Sources */,
-				919EA78B253051F1008BC359 /* WeeklyForecastEntity.swift in Sources */,
+				919EA78B253051F1008BC359 /* DailyWeatherForecastEntity.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NextSunnyDay/API/OpenWeatherAPI/DailyWeatherForecastResponse.swift
+++ b/NextSunnyDay/API/OpenWeatherAPI/DailyWeatherForecastResponse.swift
@@ -1,5 +1,5 @@
 //
-//  WeeklyForecastResponse.swift
+//  DailyWeatherForecastResponse.swift
 //  NextSunnyDay
 //
 //  Created by rMac on 2020/10/01.
@@ -7,8 +7,8 @@
 
 import Foundation
 
-// MARK: - WeeklyForecastResponse
-struct WeeklyForecastResponse: Codable {
+// MARK: - DailyWeatherForecastResponse
+struct DailyWeatherForecastResponse: Codable {
     let lat: Double
     let lon: Double
     let timezone: String

--- a/NextSunnyDay/API/OpenWeatherAPI/WeatherFetcher.swift
+++ b/NextSunnyDay/API/OpenWeatherAPI/WeatherFetcher.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol WeatherFetchable {
     func weeklyWeatherForecast(
         forLat lat: Double, forLon lon: Double
-    ) -> AnyPublisher<WeeklyForecastResponse, WeatherError>
+    ) -> AnyPublisher<DailyWeatherForecastResponse, WeatherError>
 }
 
 class WeatherFetcher {
@@ -68,7 +68,7 @@ private extension WeatherFetcher {
 extension WeatherFetcher: WeatherFetchable {
     func weeklyWeatherForecast(
         forLat lat: Double, forLon lon: Double
-    ) -> AnyPublisher<WeeklyForecastResponse, WeatherError> {
+    ) -> AnyPublisher<DailyWeatherForecastResponse, WeatherError> {
         forecast(with: makeWeeklyForecastComponents(withLat: lat, withLon: lon))
     }
 

--- a/NextSunnyDay/Model/DailyWeatherForecastEntity.swift
+++ b/NextSunnyDay/Model/DailyWeatherForecastEntity.swift
@@ -1,5 +1,5 @@
 //
-//  WeeklyForecastEntity.swift
+//  DailyWeatherForecastEntity.swift
 //  NextSunnyDay
 //
 //  Created by rMac on 2020/10/09.
@@ -8,8 +8,8 @@
 import Foundation
 import RealmSwift
 
-// MARK: - WeeklyForecastEntity
-class WeeklyForecastEntity: Object, Identifiable {
+// MARK: - DailyWeatherForecastEntity
+class DailyWeatherForecastEntity: Object, Identifiable {
     @objc dynamic var lat: Double = 0.0
     @objc dynamic var lon: Double = 0.0
     @objc dynamic var timezone: String = ""
@@ -63,10 +63,10 @@ class Weather: Object, Identifiable {
 }
 
 // MARK: - CRUD
-extension WeeklyForecastEntity {
+extension DailyWeatherForecastEntity {
     private static var realm = try! Realm()
 
-    static func all() -> Results<WeeklyForecastEntity> {
+    static func all() -> Results<DailyWeatherForecastEntity> {
         realm.objects(self)
     }
 
@@ -76,7 +76,7 @@ extension WeeklyForecastEntity {
         }
     }
 
-    static func create(with weeklyWeather: WeeklyForecastEntity) {
+    static func create(with weeklyWeather: DailyWeatherForecastEntity) {
         try! realm.write {
             realm.add(weeklyWeather)
         }

--- a/NextSunnyDay/Resourece/strings/Home.strings
+++ b/NextSunnyDay/Resourece/strings/Home.strings
@@ -6,5 +6,5 @@
   
 */
 
-"navigationBarTitle" = "次の晴れの日☀️";
+"navigationBarTitle" = "次に晴れる日☀️";
 "emptyText" = "右上の設定ボタンから\n地域を設定しましょう";


### PR DESCRIPTION
# Issue
close #17 

# 対応詳細
- 文字列修正
    - `次の晴れの日 `-> `次に晴れる日`
- 命名修正
    - `WeeklyForecastResponse` -> `DailyWeatherForecastResponse`
    - `WeeklyForecastEntity` -> `DailyWeatherForecastEntity`