### PR TITLE
次に晴れる日Widgetの元となるViewを実装

### DIFF
--- a/NextSunnyDay.xcodeproj/project.pbxproj
+++ b/NextSunnyDay.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		915F51402521763600B4E384 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 915F513F2521763600B4E384 /* Preview Assets.xcassets */; };
 		915F514B2521763600B4E384 /* NextSunnyDayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915F514A2521763600B4E384 /* NextSunnyDayTests.swift */; };
 		915F51562521763600B4E384 /* NextSunnyDayUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915F51552521763600B4E384 /* NextSunnyDayUITests.swift */; };
+		917094E82535423C00975181 /* NextSunnyDayMediumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917094E72535423C00975181 /* NextSunnyDayMediumView.swift */; };
+		917094ED2535427000975181 /* NextSunnyDay.strings in Resources */ = {isa = PBXBuildFile; fileRef = 917094EC2535427000975181 /* NextSunnyDay.strings */; };
 		917E414E2525B13F00D77C3F /* DailyWeatherForecastResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E414D2525B13F00D77C3F /* DailyWeatherForecastResponse.swift */; };
 		917E415F2525C85600D77C3F /* WeatherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E415E2525C85600D77C3F /* WeatherError.swift */; };
 		917E41642525CA5D00D77C3F /* AccessTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E41632525CA5D00D77C3F /* AccessTokens.swift */; };
@@ -61,6 +63,8 @@
 		915F51512521763600B4E384 /* NextSunnyDayUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NextSunnyDayUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		915F51552521763600B4E384 /* NextSunnyDayUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextSunnyDayUITests.swift; sourceTree = "<group>"; };
 		915F51572521763600B4E384 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		917094E72535423C00975181 /* NextSunnyDayMediumView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextSunnyDayMediumView.swift; sourceTree = "<group>"; };
+		917094EC2535427000975181 /* NextSunnyDay.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = NextSunnyDay.strings; sourceTree = "<group>"; };
 		917E414D2525B13F00D77C3F /* DailyWeatherForecastResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyWeatherForecastResponse.swift; sourceTree = "<group>"; };
 		917E415E2525C85600D77C3F /* WeatherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherError.swift; sourceTree = "<group>"; };
 		917E41632525CA5D00D77C3F /* AccessTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokens.swift; sourceTree = "<group>"; };
@@ -119,6 +123,7 @@
 			children = (
 				91500CE12533497200D5F47D /* SystemName.strings */,
 				91500CD82533476F00D5F47D /* Home.strings */,
+				917094EC2535427000975181 /* NextSunnyDay.strings */,
 			);
 			path = strings;
 			sourceTree = "<group>";
@@ -224,6 +229,7 @@
 			isa = PBXGroup;
 			children = (
 				915F513A2521763500B4E384 /* HomeView.swift */,
+				917094E72535423C00975181 /* NextSunnyDayMediumView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -361,6 +367,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				915F51402521763600B4E384 /* Preview Assets.xcassets in Resources */,
+				917094ED2535427000975181 /* NextSunnyDay.strings in Resources */,
 				915F513D2521763600B4E384 /* Assets.xcassets in Resources */,
 				91500CD92533476F00D5F47D /* Home.strings in Resources */,
 				91500CE22533497200D5F47D /* SystemName.strings in Resources */,
@@ -436,6 +443,7 @@
 				91500CCF2533404300D5F47D /* R.generated.swift in Sources */,
 				915F51392521763500B4E384 /* NextSunnyDayApp.swift in Sources */,
 				917E41642525CA5D00D77C3F /* AccessTokens.swift in Sources */,
+				917094E82535423C00975181 /* NextSunnyDayMediumView.swift in Sources */,
 				91A2960F2534369F00CCC7B2 /* ViewModelObject.swift in Sources */,
 				917E415F2525C85600D77C3F /* WeatherError.swift in Sources */,
 				919EA78B253051F1008BC359 /* DailyWeatherForecastEntity.swift in Sources */,

--- a/NextSunnyDay.xcodeproj/project.pbxproj
+++ b/NextSunnyDay.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		919EA78B253051F1008BC359 /* DailyWeatherForecastEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919EA78A253051F1008BC359 /* DailyWeatherForecastEntity.swift */; };
 		91A2960F2534369F00CCC7B2 /* ViewModelObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2960E2534369F00CCC7B2 /* ViewModelObject.swift */; };
 		91A2961725344DB700CCC7B2 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2961625344DB700CCC7B2 /* HomeViewModel.swift */; };
+		91DDF1A2253699DC009F9A96 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DDF1A1253699DC009F9A96 /* Date+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +79,7 @@
 		919EA78A253051F1008BC359 /* DailyWeatherForecastEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyWeatherForecastEntity.swift; sourceTree = "<group>"; };
 		91A2960E2534369F00CCC7B2 /* ViewModelObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelObject.swift; sourceTree = "<group>"; };
 		91A2961625344DB700CCC7B2 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		91DDF1A1253699DC009F9A96 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -211,6 +213,7 @@
 		915F516B2521881D00B4E384 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				91DDF1A1253699DC009F9A96 /* Date+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -450,6 +453,7 @@
 				917094FA253549DC00975181 /* NextSunnyDayViewModel.swift in Sources */,
 				915F513B2521763500B4E384 /* HomeView.swift in Sources */,
 				91A2961725344DB700CCC7B2 /* HomeViewModel.swift in Sources */,
+				91DDF1A2253699DC009F9A96 /* Date+Extension.swift in Sources */,
 				91500CCF2533404300D5F47D /* R.generated.swift in Sources */,
 				915F51392521763500B4E384 /* NextSunnyDayApp.swift in Sources */,
 				917E41642525CA5D00D77C3F /* AccessTokens.swift in Sources */,

--- a/NextSunnyDay.xcodeproj/project.pbxproj
+++ b/NextSunnyDay.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		915F51562521763600B4E384 /* NextSunnyDayUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915F51552521763600B4E384 /* NextSunnyDayUITests.swift */; };
 		917094E82535423C00975181 /* NextSunnyDayMediumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917094E72535423C00975181 /* NextSunnyDayMediumView.swift */; };
 		917094ED2535427000975181 /* NextSunnyDay.strings in Resources */ = {isa = PBXBuildFile; fileRef = 917094EC2535427000975181 /* NextSunnyDay.strings */; };
+		917094F2253545DB00975181 /* NextSunnyDaySmallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917094F1253545DB00975181 /* NextSunnyDaySmallView.swift */; };
 		917E414E2525B13F00D77C3F /* DailyWeatherForecastResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E414D2525B13F00D77C3F /* DailyWeatherForecastResponse.swift */; };
 		917E415F2525C85600D77C3F /* WeatherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E415E2525C85600D77C3F /* WeatherError.swift */; };
 		917E41642525CA5D00D77C3F /* AccessTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E41632525CA5D00D77C3F /* AccessTokens.swift */; };
@@ -65,6 +66,7 @@
 		915F51572521763600B4E384 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		917094E72535423C00975181 /* NextSunnyDayMediumView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextSunnyDayMediumView.swift; sourceTree = "<group>"; };
 		917094EC2535427000975181 /* NextSunnyDay.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = NextSunnyDay.strings; sourceTree = "<group>"; };
+		917094F1253545DB00975181 /* NextSunnyDaySmallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextSunnyDaySmallView.swift; sourceTree = "<group>"; };
 		917E414D2525B13F00D77C3F /* DailyWeatherForecastResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyWeatherForecastResponse.swift; sourceTree = "<group>"; };
 		917E415E2525C85600D77C3F /* WeatherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherError.swift; sourceTree = "<group>"; };
 		917E41632525CA5D00D77C3F /* AccessTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokens.swift; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 			isa = PBXGroup;
 			children = (
 				915F513A2521763500B4E384 /* HomeView.swift */,
+				917094F1253545DB00975181 /* NextSunnyDaySmallView.swift */,
 				917094E72535423C00975181 /* NextSunnyDayMediumView.swift */,
 			);
 			path = View;
@@ -444,6 +447,7 @@
 				915F51392521763500B4E384 /* NextSunnyDayApp.swift in Sources */,
 				917E41642525CA5D00D77C3F /* AccessTokens.swift in Sources */,
 				917094E82535423C00975181 /* NextSunnyDayMediumView.swift in Sources */,
+				917094F2253545DB00975181 /* NextSunnyDaySmallView.swift in Sources */,
 				91A2960F2534369F00CCC7B2 /* ViewModelObject.swift in Sources */,
 				917E415F2525C85600D77C3F /* WeatherError.swift in Sources */,
 				919EA78B253051F1008BC359 /* DailyWeatherForecastEntity.swift in Sources */,

--- a/NextSunnyDay.xcodeproj/project.pbxproj
+++ b/NextSunnyDay.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		917094E82535423C00975181 /* NextSunnyDayMediumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917094E72535423C00975181 /* NextSunnyDayMediumView.swift */; };
 		917094ED2535427000975181 /* NextSunnyDay.strings in Resources */ = {isa = PBXBuildFile; fileRef = 917094EC2535427000975181 /* NextSunnyDay.strings */; };
 		917094F2253545DB00975181 /* NextSunnyDaySmallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917094F1253545DB00975181 /* NextSunnyDaySmallView.swift */; };
+		917094FA253549DC00975181 /* NextSunnyDayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917094F9253549DC00975181 /* NextSunnyDayViewModel.swift */; };
+		917094FF2535559000975181 /* WeatherConditionCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917094FE2535559000975181 /* WeatherConditionCode.swift */; };
 		917E414E2525B13F00D77C3F /* DailyWeatherForecastResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E414D2525B13F00D77C3F /* DailyWeatherForecastResponse.swift */; };
 		917E415F2525C85600D77C3F /* WeatherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E415E2525C85600D77C3F /* WeatherError.swift */; };
 		917E41642525CA5D00D77C3F /* AccessTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E41632525CA5D00D77C3F /* AccessTokens.swift */; };
@@ -67,6 +69,8 @@
 		917094E72535423C00975181 /* NextSunnyDayMediumView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextSunnyDayMediumView.swift; sourceTree = "<group>"; };
 		917094EC2535427000975181 /* NextSunnyDay.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = NextSunnyDay.strings; sourceTree = "<group>"; };
 		917094F1253545DB00975181 /* NextSunnyDaySmallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextSunnyDaySmallView.swift; sourceTree = "<group>"; };
+		917094F9253549DC00975181 /* NextSunnyDayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextSunnyDayViewModel.swift; sourceTree = "<group>"; };
+		917094FE2535559000975181 /* WeatherConditionCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherConditionCode.swift; sourceTree = "<group>"; };
 		917E414D2525B13F00D77C3F /* DailyWeatherForecastResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyWeatherForecastResponse.swift; sourceTree = "<group>"; };
 		917E415E2525C85600D77C3F /* WeatherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherError.swift; sourceTree = "<group>"; };
 		917E41632525CA5D00D77C3F /* AccessTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokens.swift; sourceTree = "<group>"; };
@@ -223,6 +227,7 @@
 			isa = PBXGroup;
 			children = (
 				91A2961625344DB700CCC7B2 /* HomeViewModel.swift */,
+				917094F9253549DC00975181 /* NextSunnyDayViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -251,6 +256,7 @@
 				917E414D2525B13F00D77C3F /* DailyWeatherForecastResponse.swift */,
 				917E416B2525CE6C00D77C3F /* WeatherFetcher.swift */,
 				917E415E2525C85600D77C3F /* WeatherError.swift */,
+				917094FE2535559000975181 /* WeatherConditionCode.swift */,
 			);
 			path = OpenWeatherAPI;
 			sourceTree = "<group>";
@@ -441,6 +447,7 @@
 			files = (
 				917E416C2525CE6C00D77C3F /* WeatherFetcher.swift in Sources */,
 				917E414E2525B13F00D77C3F /* DailyWeatherForecastResponse.swift in Sources */,
+				917094FA253549DC00975181 /* NextSunnyDayViewModel.swift in Sources */,
 				915F513B2521763500B4E384 /* HomeView.swift in Sources */,
 				91A2961725344DB700CCC7B2 /* HomeViewModel.swift in Sources */,
 				91500CCF2533404300D5F47D /* R.generated.swift in Sources */,
@@ -451,6 +458,7 @@
 				91A2960F2534369F00CCC7B2 /* ViewModelObject.swift in Sources */,
 				917E415F2525C85600D77C3F /* WeatherError.swift in Sources */,
 				919EA78B253051F1008BC359 /* DailyWeatherForecastEntity.swift in Sources */,
+				917094FF2535559000975181 /* WeatherConditionCode.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NextSunnyDay/API/OpenWeatherAPI/WeatherConditionCode.swift
+++ b/NextSunnyDay/API/OpenWeatherAPI/WeatherConditionCode.swift
@@ -1,0 +1,84 @@
+//
+//  WeatherConditionCode.swift
+//  NextSunnyDay
+//
+//  Created by rMac on 2020/10/13.
+//
+
+enum WeatherConditionCode: Int {
+    // MARK: - Group 2xx: Thunderstorm
+    case thunderstormWithLightRain = 200
+    case thunderstormWithRain = 201
+    case thunderstormWithHeavyRain = 202
+    case lightThunderstorm = 210
+    case thunderstorm = 211
+    case heavyThunderstorm = 212
+    case raggedThunderstorm = 221
+    case thunderstormWithLightDrizzle = 230
+    case thunderstormWithDrizzle = 231
+    case thunderstormWithHeavyDrizzle = 232
+
+    // MARK: - Group 3xx: Drizzle
+    case lightIntensityDrizzle = 300
+    case drizzle = 301
+    case heavyIntensityDrizzle = 302
+    case lightIntensityDrizzleRain = 310
+    case drizzleRain = 311
+    case heavyIntensityDrizzleRain = 312
+    case showerRainAndDrizzle = 313
+    case heavyShowerRainAndDrizzle = 314
+    case showerDrizzle = 321
+
+    // MARK: - Group 5xx: Rain
+    case lightRain = 500
+    case moderateRain = 501
+    case heavyIntensityRain = 502
+    case veryHeavyRain = 503
+    case extremeRain = 504
+    case freezingRain = 511
+    case lightIntensityShowerRain = 520
+    case showerRain = 521
+    case heavyIntensityShowerRain = 522
+    case raggedShowerRain = 531
+
+    // MARK: - Group 6xx: Snow
+    case lightSnow = 600
+    case snow = 601
+    case heavySnow = 602
+    case sleet = 611
+    case lightShowerSleet = 612
+    case showerSleet = 613
+    case lightRainAndSnow = 615
+    case rainAndSnow = 616
+    case lightShowerSnow = 620
+    case showerSnow = 621
+    case heavyShowerSnow = 622
+
+    // MARK: - Group 7xx: Atmosphere
+    case mist = 701
+    case smoke = 711
+    case haze = 721
+    case sandAmdDustWhirls = 731
+    case fog = 741
+    case sand = 751
+    case dust = 761
+    case volcanicAsh = 762
+    case squalls = 771
+    case tornado = 781
+
+    // MARK: - Group 800: Clear
+    case clearSky = 800
+
+    // MARK: - Group 80x: Clouds
+    case fewClouds = 801
+    case scatteredClouds = 802
+    case brokenClouds = 803
+    case overcastClouds = 804
+}
+
+// MARK: - SunnyCodes
+let sunnyCodes = [
+    WeatherConditionCode.clearSky.rawValue,
+    WeatherConditionCode.fewClouds.rawValue,
+    WeatherConditionCode.scatteredClouds.rawValue
+]

--- a/NextSunnyDay/Assets.xcassets/NextSunnyDayBackgroudColor.colorset/Contents.json
+++ b/NextSunnyDay/Assets.xcassets/NextSunnyDayBackgroudColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3D",
+          "green" : "0x7A",
+          "red" : "0xD1"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x1C",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NextSunnyDay/Assets.xcassets/NoSunnyDayBackgroundColor.colorset/Contents.json
+++ b/NextSunnyDay/Assets.xcassets/NoSunnyDayBackgroundColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x82",
+          "green" : "0x82",
+          "red" : "0x82"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x82",
+          "green" : "0x82",
+          "red" : "0x82"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NextSunnyDay/Extension/Date+Extension.swift
+++ b/NextSunnyDay/Extension/Date+Extension.swift
@@ -1,0 +1,41 @@
+//
+//  Date+Extension.swift
+//  NextSunnyDay
+//
+//  Created by rMac on 2020/10/14.
+//
+
+import Foundation
+
+extension Date {
+    /*
+     yy     西暦年  2桁             2012年 -> 12
+     yyyy   西暦年  4桁             2012年 -> 2012
+     M      月                     8月 -> 8
+     MM     月(ゼロ埋め)             8月 -> 08
+     d      月に対する日             3日 -> 3
+     dd     月に対する日(ゼロ埋め)     3日 -> 03
+     e      曜日                   2011年8月30日 -> 3
+     E      曜日(漢字)              2011年8月30日 -> 火
+     a      午前/午後               13:00 -> 午後
+     h      時(12時間制)            13時 -> 1
+     hh     時(12時間制ゼロ埋め)      13時 -> 01
+     H      時(24時間制             13時 -> 13
+     HH     時(24時間制ゼロ埋め)      13時 -> 13
+     m      分                     3分 -> 3
+     mm     分(ゼロ埋め)             3分 -> 03
+     s      秒                     3秒 -> 3
+     ss     秒(ゼロ埋め)             3秒 -> 03
+     S      ミリ秒                 3ミリ秒 -> 3
+     SSS    ミリ秒(ゼロ埋め)         3ミリ秒 -> 003
+     */
+    /// Date Format (ja_JP)
+    /// - Parameter text: dateFormat
+    /// - Returns:Formated Text
+    func format(text: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "ja_JP")
+        dateFormatter.dateFormat = text
+        return dateFormatter.string(from: self)
+    }
+}

--- a/NextSunnyDay/Model/DailyWeatherForecastEntity.swift
+++ b/NextSunnyDay/Model/DailyWeatherForecastEntity.swift
@@ -10,6 +10,7 @@ import RealmSwift
 
 // MARK: - DailyWeatherForecastEntity
 class DailyWeatherForecastEntity: Object, Identifiable {
+    @objc dynamic var cityName: String = ""
     @objc dynamic var lat: Double = 0.0
     @objc dynamic var lon: Double = 0.0
     @objc dynamic var timezone: String = ""

--- a/NextSunnyDay/Resourece/strings/NextSunnyDay.strings
+++ b/NextSunnyDay/Resourece/strings/NextSunnyDay.strings
@@ -1,0 +1,11 @@
+/*
+  NextSunnyDay.strings
+  NextSunnyDay
+
+  Created by rMac on 2020/10/13.
+  
+*/
+
+"nextSunnyDay" = "次に晴れる日";
+"max" = "MAX";
+"min" = "MIN";

--- a/NextSunnyDay/Resourece/strings/NextSunnyDay.strings
+++ b/NextSunnyDay/Resourece/strings/NextSunnyDay.strings
@@ -9,3 +9,5 @@
 "nextSunnyDay" = "次に晴れる日";
 "max" = "MAX";
 "min" = "MIN";
+"nextWeekOnwards" = "来週以降";
+"hyphen" = "-";

--- a/NextSunnyDay/Resourece/strings/NextSunnyDay.strings
+++ b/NextSunnyDay/Resourece/strings/NextSunnyDay.strings
@@ -7,7 +7,7 @@
 */
 
 "nextSunnyDay" = "次に晴れる日";
-"max" = "MAX";
-"min" = "MIN";
+"max" = "最高";
+"min" = "最低";
 "nextWeekOnwards" = "来週以降";
 "hyphen" = "-";

--- a/NextSunnyDay/View/HomeView.swift
+++ b/NextSunnyDay/View/HomeView.swift
@@ -18,10 +18,16 @@ struct HomeView<T>: View where T: HomeViewModelObject {
         NavigationView {
             ZStack {
                 Color(.systemGroupedBackground).edgesIgnoringSafeArea(.all)
-                if viewModel.output.dataSource.isEmpty {
+                if viewModel.output.forecast.daily.isEmpty {
                     emptyView
                 } else {
-                    // TODO: NextSunnyDayView and WeeklyForecastView
+                    ScrollView {
+                        VStack {
+                            Spacer().frame(height: 12)
+                            nextSunnyDayView
+                            // TODO: Add WeeklyForecastView
+                        }
+                    }
                 }
             }
             .navigationBarTitle(R.string.home.navigationBarTitle())
@@ -51,13 +57,23 @@ private extension HomeView {
         }
         .foregroundColor(.gray)
     }
+
+    var nextSunnyDayView: some View {
+        HStack {
+            Spacer()
+                .frame(maxWidth: 18)
+            NextSunnyDayMediumView(viewModel: NextSunnyDayViewModel(viewModel.output.forecast))
+            Spacer()
+                .frame(maxWidth: 18)
+        }
+    }
 }
 
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            HomeView(viewModel: MockViewModel(dataSource: []))
-            HomeView(viewModel: MockViewModel(dataSource: [Daily()]))
+            HomeView(viewModel: MockViewModel())
+            HomeView(viewModel: MockViewModel(forecast: mockEntity()))
         }
     }
 }
@@ -69,7 +85,7 @@ extension HomeView_Previews {
         final class Binding: HomeViewModelBindingObject {}
 
         final class Output: HomeViewModelOutputObject {
-            @Published var dataSource: [Daily] = []
+            @Published var forecast = DailyWeatherForecastEntity()
         }
 
         var input: Input
@@ -78,16 +94,36 @@ extension HomeView_Previews {
 
         var output: Output
 
-        init(dataSource: [Daily]) {
+        init(forecast: DailyWeatherForecastEntity = DailyWeatherForecastEntity()) {
             let input = Input()
             let binding = Binding()
             let output = Output()
 
-            output.dataSource = dataSource
+            output.forecast = forecast
 
             self.input = input
             self.binding = binding
             self.output = output
         }
+    }
+
+    private static func mockEntity() -> DailyWeatherForecastEntity {
+        let mockEntity = DailyWeatherForecastEntity()
+        let daily = Daily()
+        let temp = Temp()
+        let feelsLike = FeelsLike()
+        let weather = Weather()
+
+        temp.min = 2.0
+        temp.max = 11.0
+        weather.id = 800
+        daily.date = 1_608_606_000
+        daily.temp = temp
+        daily.feelsLike = feelsLike
+        daily.weather.append(weather)
+        mockEntity.cityName = "東京都港区"
+        mockEntity.daily.append(daily)
+
+        return mockEntity
     }
 }

--- a/NextSunnyDay/View/NextSunnyDayMediumView.swift
+++ b/NextSunnyDay/View/NextSunnyDayMediumView.swift
@@ -20,7 +20,7 @@ struct NextSunnyDayMediumView<T>: View where T: NextSunnyDayViewModelObject {
                 .edgesIgnoringSafeArea(.all)
             VStack {
                 Spacer()
-                    .frame(minHeight: 16)
+                    .frame(idealHeight: 20)
                 HStack {
                     Spacer()
                         .frame(maxWidth: 16)
@@ -76,7 +76,7 @@ struct NextSunnyDayMediumView<T>: View where T: NextSunnyDayViewModelObject {
                         .frame(maxWidth: 20)
                 }
                 Spacer()
-                    .frame(maxHeight: 16)
+                    .frame(idealHeight: 20)
             }
         }
         .foregroundColor(.white)

--- a/NextSunnyDay/View/NextSunnyDayMediumView.swift
+++ b/NextSunnyDay/View/NextSunnyDayMediumView.swift
@@ -7,10 +7,16 @@
 
 import SwiftUI
 
-struct NextSunnyDayMediumView: View {
+struct NextSunnyDayMediumView<T>: View where T: NextSunnyDayViewModelObject {
+    @ObservedObject private var viewModel: T
+
+    init(viewModel: T) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
         ZStack {
-            Color(R.color.nextSunnyDayBackgroudColor() ?? .black)
+            viewModel.output.backgroundColor
                 .edgesIgnoringSafeArea(.all)
             VStack {
                 Spacer()
@@ -31,28 +37,25 @@ struct NextSunnyDayMediumView: View {
                     Spacer()
                         .frame(maxWidth: 20)
                     VStack(alignment: .leading) {
-                        // TODO: Published from ViewModel
-                        Text("東京都港区")
+                        Text(viewModel.output.cityName)
                             .font(.system(size: 16))
                             .fontWeight(.semibold)
                             .fixedSize()
                         Spacer()
                             .frame(maxHeight: 8)
-                        // TODO: Published from ViewModel
-                        Text("12/22 (火)")
+                        Text(viewModel.output.nextSunnyDay)
                             .font(.system(size: 40))
                             .fontWeight(.bold)
                             .fixedSize()
                     }
                     Spacer()
                         .frame(maxWidth: 40)
-                    VStack {
+                    VStack(alignment: .leading) {
                         VStack(alignment: .leading) {
                             Text(R.string.nextSunnyDay.max())
-                                .font(.system(size: 10))
+                                .font(.system(size: 14))
                                 .fixedSize()
-                            // TODO: Published from ViewModel
-                            Text("28℃")
+                            Text(viewModel.output.maxTemperature)
                                 .font(.system(size: 18))
                                 .fontWeight(.semibold)
                                 .fixedSize()
@@ -61,10 +64,9 @@ struct NextSunnyDayMediumView: View {
                             .frame(maxHeight: 12)
                         VStack(alignment: .leading) {
                             Text(R.string.nextSunnyDay.min())
-                                .font(.system(size: 10))
+                                .font(.system(size: 14))
                                 .fixedSize()
-                            // TODO: Published from ViewModel
-                            Text("21℃")
+                            Text(viewModel.output.minTemperature)
                                 .font(.system(size: 18))
                                 .fontWeight(.semibold)
                                 .fixedSize()
@@ -84,7 +86,10 @@ struct NextSunnyDayMediumView: View {
 
 struct NextSunnyDayMediumView_Previews: PreviewProvider {
     static var contentView: some View {
-        NextSunnyDayMediumView()
+        Group {
+            NextSunnyDayMediumView(viewModel: MockViewModel(nextSunnyDay: "12/22 (火)", maxTemperature: "10.0℃", minTemperature: "2.0℃"))
+            NextSunnyDayMediumView(viewModel: MockViewModel(backgroundColor: Color(R.color.noSunnyDayBackgroundColor() ?? .gray)))
+        }
     }
 
     static var previews: some View {
@@ -108,6 +113,50 @@ struct NextSunnyDayMediumView_Previews: PreviewProvider {
             // 414pt × 896pt (iPhone XR/XS Max/11/11 Pro Max)
             contentView
                 .previewLayout(.fixed(width: 360.0, height: 169.0))
+        }
+    }
+}
+
+extension NextSunnyDayMediumView_Previews {
+    final class MockViewModel: NextSunnyDayViewModelObject {
+        final class Input: NextSunnyDayViewModelInputObject {}
+
+        final class Binding: NextSunnyDayViewModelBindingObject {}
+
+        final class Output: NextSunnyDayViewModelOutputObject {
+            @Published var backgroundColor = Color(R.color.nextSunnyDayBackgroudColor() ?? .orange)
+            @Published var cityName = ""
+            @Published var nextSunnyDay = ""
+            @Published var maxTemperature = ""
+            @Published var minTemperature = ""
+        }
+
+        var input: Input
+
+        var binding: Binding
+
+        var output: Output
+
+        init(
+            backgroundColor: Color = Color(R.color.nextSunnyDayBackgroudColor() ?? .orange),
+            cityName: String = "東京都港区",
+            nextSunnyDay: String = R.string.nextSunnyDay.nextWeekOnwards(),
+            maxTemperature: String = R.string.nextSunnyDay.hyphen(),
+            minTemperature: String = R.string.nextSunnyDay.hyphen()
+        ) {
+            let input = Input()
+            let binding = Binding()
+            let output = Output()
+
+            output.cityName = cityName
+            output.nextSunnyDay = nextSunnyDay
+            output.backgroundColor = backgroundColor
+            output.maxTemperature = maxTemperature
+            output.minTemperature = minTemperature
+
+            self.input = input
+            self.binding = binding
+            self.output = output
         }
     }
 }

--- a/NextSunnyDay/View/NextSunnyDayMediumView.swift
+++ b/NextSunnyDay/View/NextSunnyDayMediumView.swift
@@ -1,0 +1,113 @@
+//
+//  NextSunnyDayMediumView.swift
+//  NextSunnyDay
+//
+//  Created by rMac on 2020/10/13.
+//
+
+import SwiftUI
+
+struct NextSunnyDayMediumView: View {
+    var body: some View {
+        ZStack {
+            Color(R.color.nextSunnyDayBackgroudColor() ?? .black)
+                .edgesIgnoringSafeArea(.all)
+            VStack {
+                Spacer()
+                    .frame(minHeight: 16)
+                HStack {
+                    Spacer()
+                        .frame(maxWidth: 16)
+                    Image(systemName: R.string.systemName.sunMinFill())
+                    Text(R.string.nextSunnyDay.nextSunnyDay())
+                        .font(.system(size: 18))
+                        .fontWeight(.semibold)
+                        .fixedSize()
+                    Spacer()
+                }
+                Spacer()
+                    .frame(maxHeight: 32)
+                HStack {
+                    Spacer()
+                        .frame(maxWidth: 20)
+                    VStack(alignment: .leading) {
+                        // TODO: Published from ViewModel
+                        Text("東京都港区")
+                            .font(.system(size: 16))
+                            .fontWeight(.semibold)
+                            .fixedSize()
+                        Spacer()
+                            .frame(maxHeight: 8)
+                        // TODO: Published from ViewModel
+                        Text("12/22 (火)")
+                            .font(.system(size: 40))
+                            .fontWeight(.bold)
+                            .fixedSize()
+                    }
+                    Spacer()
+                        .frame(maxWidth: 40)
+                    VStack {
+                        VStack(alignment: .leading) {
+                            Text(R.string.nextSunnyDay.max())
+                                .font(.system(size: 10))
+                                .fixedSize()
+                            // TODO: Published from ViewModel
+                            Text("28℃")
+                                .font(.system(size: 18))
+                                .fontWeight(.semibold)
+                                .fixedSize()
+                        }
+                        Spacer()
+                            .frame(maxHeight: 12)
+                        VStack(alignment: .leading) {
+                            Text(R.string.nextSunnyDay.min())
+                                .font(.system(size: 10))
+                                .fixedSize()
+                            // TODO: Published from ViewModel
+                            Text("21℃")
+                                .font(.system(size: 18))
+                                .fontWeight(.semibold)
+                                .fixedSize()
+                        }
+                    }
+                    Spacer()
+                        .frame(maxWidth: 20)
+                }
+                Spacer()
+                    .frame(maxHeight: 16)
+            }
+        }
+        .foregroundColor(.white)
+        .cornerRadius(30)
+    }
+}
+
+struct NextSunnyDayMediumView_Previews: PreviewProvider {
+    static var contentView: some View {
+        NextSunnyDayMediumView()
+    }
+
+    static var previews: some View {
+        Group {
+            // 320pt × 568pt (iPhone SE 第1世代)
+            contentView
+                .previewLayout(.fixed(width: 291.0, height: 141.0))
+
+            // 375pt × 667pt (iPhone 6/6s/7/7s/8/SE 第2世代)
+            contentView
+                .previewLayout(.fixed(width: 322.0, height: 148.0))
+
+            // 414pt × 736pt (iPhone 6 Plus/6s Plus/7 Plus/8 Plus)
+            contentView
+                .previewLayout(.fixed(width: 348.0, height: 159.0))
+
+            // 375pt × 812pt (iPhone X/XS/11 Pro)
+            contentView
+                .previewLayout(.fixed(width: 329.0, height: 155.0))
+
+            // 414pt × 896pt (iPhone XR/XS Max/11/11 Pro Max)
+            contentView
+                .previewLayout(.fixed(width: 360.0, height: 169.0))
+        }
+    }
+}

--- a/NextSunnyDay/View/NextSunnyDaySmallView.swift
+++ b/NextSunnyDay/View/NextSunnyDaySmallView.swift
@@ -1,0 +1,89 @@
+//
+//  NextSunnyDaySmallView.swift
+//  NextSunnyDay
+//
+//  Created by rMac on 2020/10/13.
+//
+
+import SwiftUI
+
+struct NextSunnyDaySmallView: View {
+    var body: some View {
+        ZStack {
+            Color(R.color.nextSunnyDayBackgroudColor() ?? .black)
+                .edgesIgnoringSafeArea(.all)
+            VStack {
+                Spacer()
+                    .frame(maxHeight: 14)
+                HStack {
+                    Spacer()
+                        .frame(maxWidth: 12)
+                    Image(systemName: R.string.systemName.sunMinFill())
+                        .resizable()
+                        .frame(width: 14, height: 14)
+                    Text(R.string.nextSunnyDay.nextSunnyDay())
+                        .font(.system(size: 14))
+                        .fontWeight(.semibold)
+                        .fixedSize()
+                    Spacer()
+                }
+                Spacer()
+                    .frame(maxHeight: 20)
+                HStack {
+                    Spacer()
+                        .frame(maxWidth: 20)
+                    VStack(alignment: .leading) {
+                        // TODO: Published from ViewModel
+                        Text("東京都港区")
+                            .font(.system(size: 16))
+                            .fontWeight(.semibold)
+                            .fixedSize()
+                        Spacer()
+                            .frame(maxHeight: 8)
+                        // TODO: Published from ViewModel
+                        Text("12/22 (火)")
+                            .font(.system(size: 28))
+                            .fontWeight(.bold)
+                            .fixedSize()
+                    }
+                    Spacer()
+                        .frame(maxWidth: 20)
+                }
+                Spacer()
+                    .frame(maxHeight: 16)
+            }
+        }
+        .foregroundColor(.white)
+        .cornerRadius(30)
+    }
+}
+
+struct NextSunnyDaySmallView_Previews: PreviewProvider {
+    static var contentView: some View {
+        NextSunnyDaySmallView()
+    }
+
+    static var previews: some View {
+        Group {
+            // 320pt × 568pt (iPhone SE 第1世代)
+            contentView
+                .previewLayout(.fixed(width: 141.0, height: 141.0))
+
+            // 375pt × 667pt (iPhone 6/6s/7/7s/8/SE 第2世代)
+            contentView
+                .previewLayout(.fixed(width: 148.0, height: 148.0))
+
+            // 414pt × 736pt (iPhone 6 Plus/6s Plus/7 Plus/8 Plus)
+            contentView
+                .previewLayout(.fixed(width: 159.0, height: 159.0))
+
+            // 375pt × 812pt (iPhone X/XS/11 Pro)
+            contentView
+                .previewLayout(.fixed(width: 155.0, height: 155.0))
+
+            // 414pt × 896pt (iPhone XR/XS Max/11/11 Pro Max)
+            contentView
+                .previewLayout(.fixed(width: 169.0, height: 169.0))
+        }
+    }
+}

--- a/NextSunnyDay/View/NextSunnyDaySmallView.swift
+++ b/NextSunnyDay/View/NextSunnyDaySmallView.swift
@@ -7,10 +7,16 @@
 
 import SwiftUI
 
-struct NextSunnyDaySmallView: View {
+struct NextSunnyDaySmallView<T>: View where T: NextSunnyDayViewModelObject {
+    @ObservedObject private var viewModel: T
+
+    init(viewModel: T) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
         ZStack {
-            Color(R.color.nextSunnyDayBackgroudColor() ?? .black)
+            viewModel.output.backgroundColor
                 .edgesIgnoringSafeArea(.all)
             VStack {
                 Spacer()
@@ -33,15 +39,13 @@ struct NextSunnyDaySmallView: View {
                     Spacer()
                         .frame(maxWidth: 20)
                     VStack(alignment: .leading) {
-                        // TODO: Published from ViewModel
-                        Text("東京都港区")
+                        Text(viewModel.output.cityName)
                             .font(.system(size: 16))
                             .fontWeight(.semibold)
                             .fixedSize()
                         Spacer()
                             .frame(maxHeight: 8)
-                        // TODO: Published from ViewModel
-                        Text("12/22 (火)")
+                        Text(viewModel.output.nextSunnyDay)
                             .font(.system(size: 28))
                             .fontWeight(.bold)
                             .fixedSize()
@@ -60,7 +64,10 @@ struct NextSunnyDaySmallView: View {
 
 struct NextSunnyDaySmallView_Previews: PreviewProvider {
     static var contentView: some View {
-        NextSunnyDaySmallView()
+        Group {
+            NextSunnyDaySmallView(viewModel: MockViewModel(nextSunnyDay: "12/22 (火)"))
+            NextSunnyDaySmallView(viewModel: MockViewModel(backgroundColor: Color(R.color.noSunnyDayBackgroundColor() ?? .gray)))
+        }
     }
 
     static var previews: some View {
@@ -84,6 +91,46 @@ struct NextSunnyDaySmallView_Previews: PreviewProvider {
             // 414pt × 896pt (iPhone XR/XS Max/11/11 Pro Max)
             contentView
                 .previewLayout(.fixed(width: 169.0, height: 169.0))
+        }
+    }
+}
+
+extension NextSunnyDaySmallView_Previews {
+    final class MockViewModel: NextSunnyDayViewModelObject {
+        final class Input: NextSunnyDayViewModelInputObject {}
+
+        final class Binding: NextSunnyDayViewModelBindingObject {}
+
+        final class Output: NextSunnyDayViewModelOutputObject {
+            @Published var backgroundColor = Color(R.color.nextSunnyDayBackgroudColor() ?? .orange)
+            @Published var cityName = ""
+            @Published var nextSunnyDay = ""
+            @Published var maxTemperature = ""
+            @Published var minTemperature = ""
+        }
+
+        var input: Input
+
+        var binding: Binding
+
+        var output: Output
+
+        init(
+            cityName: String = "東京都港区",
+            nextSunnyDay: String = R.string.nextSunnyDay.nextWeekOnwards(),
+            backgroundColor: Color = Color(R.color.nextSunnyDayBackgroudColor() ?? .orange)
+        ) {
+            let input = Input()
+            let binding = Binding()
+            let output = Output()
+
+            output.cityName = cityName
+            output.nextSunnyDay = nextSunnyDay
+            output.backgroundColor = backgroundColor
+
+            self.input = input
+            self.binding = binding
+            self.output = output
         }
     }
 }

--- a/NextSunnyDay/ViewModel/HomeViewModel.swift
+++ b/NextSunnyDay/ViewModel/HomeViewModel.swift
@@ -24,7 +24,7 @@ protocol HomeViewModelBindingObject: BindingObject {
 
 // MARK: - HomeViewModelOutputObject
 protocol HomeViewModelOutputObject: OutputObject {
-    var dataSource: [Daily] { get }
+    var forecast: DailyWeatherForecastEntity { get }
 }
 
 // MARK: - HomeViewModel
@@ -34,7 +34,7 @@ class HomeViewModel: HomeViewModelObject {
     final class Binding: HomeViewModelBindingObject {}
 
     final class Output: HomeViewModelOutputObject {
-        @Published var dataSource: [Daily] = []
+        @Published var forecast = DailyWeatherForecastEntity()
     }
 
     var input: Input

--- a/NextSunnyDay/ViewModel/NextSunnyDayViewModel.swift
+++ b/NextSunnyDay/ViewModel/NextSunnyDayViewModel.swift
@@ -8,6 +8,7 @@
 import Combine
 import Foundation
 import RealmSwift
+import SwiftUI
 
 // MARK: - NextSunnyDayViewModelObject
 protocol NextSunnyDayViewModelObject: ViewModelObject where Input: NextSunnyDayViewModelInputObject, Binding: NextSunnyDayViewModelBindingObject, Output: NextSunnyDayViewModelOutputObject {
@@ -26,6 +27,7 @@ protocol NextSunnyDayViewModelBindingObject: BindingObject {
 
 // MARK: - NextSunnyDayViewModelOutputObject
 protocol NextSunnyDayViewModelOutputObject: OutputObject {
+    var backgroundColor: Color { get }
     var cityName: String { get }
     var nextSunnyDay: String { get }
     var maxTemperature: String { get }
@@ -39,6 +41,7 @@ class NextSunnyDayViewModel: NextSunnyDayViewModelObject {
     final class Binding: NextSunnyDayViewModelBindingObject {}
 
     final class Output: NextSunnyDayViewModelOutputObject {
+        @Published var backgroundColor = Color(R.color.nextSunnyDayBackgroudColor() ?? .orange)
         @Published var cityName = ""
         @Published var nextSunnyDay = ""
         @Published var maxTemperature = ""
@@ -62,12 +65,13 @@ class NextSunnyDayViewModel: NextSunnyDayViewModelObject {
             let formatter = DateFormatter()
             formatter.dateFormat = "yMMMdE"
             let nextSunnyDay = formatter.string(from: Date(timeIntervalSince1970: Double(nearestSunnyDay.date)))
-            
+
             output.cityName = forecast.cityName
             output.nextSunnyDay = nextSunnyDay
             output.maxTemperature = String("\(nearestSunnyDay.temp?.max)")
             output.minTemperature = String("\(nearestSunnyDay.temp?.min)")
         } else {
+            output.backgroundColor = Color(R.color.noSunnyDayBackgroundColor() ?? .gray)
             output.cityName = forecast.cityName
             output.nextSunnyDay = R.string.nextSunnyDay.nextWeekOnwards()
             output.maxTemperature = R.string.nextSunnyDay.hyphen()

--- a/NextSunnyDay/ViewModel/NextSunnyDayViewModel.swift
+++ b/NextSunnyDay/ViewModel/NextSunnyDayViewModel.swift
@@ -1,0 +1,81 @@
+//
+//  NextSunnyDayViewModel.swift
+//  NextSunnyDay
+//
+//  Created by rMac on 2020/10/13.
+//
+
+import Combine
+import Foundation
+import RealmSwift
+
+// MARK: - NextSunnyDayViewModelObject
+protocol NextSunnyDayViewModelObject: ViewModelObject where Input: NextSunnyDayViewModelInputObject, Binding: NextSunnyDayViewModelBindingObject, Output: NextSunnyDayViewModelOutputObject {
+    var input: Input { get }
+    var binding: Binding { get }
+    var output: Output { get }
+}
+
+// MARK: - NextSunnyDayViewModelInputObject
+protocol NextSunnyDayViewModelInputObject: InputObject {
+}
+
+// MARK: - NextSunnyDayViewModelBindingObject
+protocol NextSunnyDayViewModelBindingObject: BindingObject {
+}
+
+// MARK: - NextSunnyDayViewModelOutputObject
+protocol NextSunnyDayViewModelOutputObject: OutputObject {
+    var cityName: String { get }
+    var nextSunnyDay: String { get }
+    var maxTemperature: String { get }
+    var minTemperature: String { get }
+}
+
+// MARK: - NextSunnyDayViewModel
+class NextSunnyDayViewModel: NextSunnyDayViewModelObject {
+    final class Input: NextSunnyDayViewModelInputObject {}
+
+    final class Binding: NextSunnyDayViewModelBindingObject {}
+
+    final class Output: NextSunnyDayViewModelOutputObject {
+        @Published var cityName = ""
+        @Published var nextSunnyDay = ""
+        @Published var maxTemperature = ""
+        @Published var minTemperature = ""
+    }
+
+    var input: Input
+
+    var binding: Binding
+
+    var output: Output
+
+    init(_ forecast: DailyWeatherForecastEntity) {
+        let input = Input()
+        let binding = Binding()
+        let output = Output()
+
+        // output
+        if let nearestSunnyDay = forecast.daily.filter({ sunnyCodes.contains($0.weather.first?.id ?? 0) }).min(by: { $0.date < $1.date }) {
+            // UNIX -> Date
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yMMMdE"
+            let nextSunnyDay = formatter.string(from: Date(timeIntervalSince1970: Double(nearestSunnyDay.date)))
+            
+            output.cityName = forecast.cityName
+            output.nextSunnyDay = nextSunnyDay
+            output.maxTemperature = String("\(nearestSunnyDay.temp?.max)")
+            output.minTemperature = String("\(nearestSunnyDay.temp?.min)")
+        } else {
+            output.cityName = forecast.cityName
+            output.nextSunnyDay = R.string.nextSunnyDay.nextWeekOnwards()
+            output.maxTemperature = R.string.nextSunnyDay.hyphen()
+            output.minTemperature = R.string.nextSunnyDay.hyphen()
+        }
+
+        self.input = input
+        self.binding = binding
+        self.output = output
+    }
+}

--- a/NextSunnyDay/ViewModel/NextSunnyDayViewModel.swift
+++ b/NextSunnyDay/ViewModel/NextSunnyDayViewModel.swift
@@ -41,11 +41,11 @@ class NextSunnyDayViewModel: NextSunnyDayViewModelObject {
     final class Binding: NextSunnyDayViewModelBindingObject {}
 
     final class Output: NextSunnyDayViewModelOutputObject {
-        @Published var backgroundColor = Color(R.color.nextSunnyDayBackgroudColor() ?? .orange)
+        @Published var backgroundColor = Color(R.color.noSunnyDayBackgroundColor() ?? .gray)
         @Published var cityName = ""
-        @Published var nextSunnyDay = ""
-        @Published var maxTemperature = ""
-        @Published var minTemperature = ""
+        @Published var nextSunnyDay = R.string.nextSunnyDay.nextWeekOnwards()
+        @Published var maxTemperature = R.string.nextSunnyDay.hyphen()
+        @Published var minTemperature = R.string.nextSunnyDay.hyphen()
     }
 
     var input: Input
@@ -60,22 +60,14 @@ class NextSunnyDayViewModel: NextSunnyDayViewModelObject {
         let output = Output()
 
         // output
+        output.cityName = forecast.cityName
         if let nearestSunnyDay = forecast.daily.filter({ sunnyCodes.contains($0.weather.first?.id ?? 0) }).min(by: { $0.date < $1.date }) {
-            // UNIX -> Date
-            let formatter = DateFormatter()
-            formatter.dateFormat = "MM/ddE"
-            let nextSunnyDay = formatter.string(from: Date(timeIntervalSince1970: Double(nearestSunnyDay.date)))
-
-            output.cityName = forecast.cityName
-            output.nextSunnyDay = nextSunnyDay
-            output.maxTemperature = String("\(nearestSunnyDay.temp?.max)℃")
-            output.minTemperature = String("\(nearestSunnyDay.temp?.min)℃")
-        } else {
-            output.backgroundColor = Color(R.color.noSunnyDayBackgroundColor() ?? .gray)
-            output.cityName = forecast.cityName
-            output.nextSunnyDay = R.string.nextSunnyDay.nextWeekOnwards()
-            output.maxTemperature = R.string.nextSunnyDay.hyphen()
-            output.minTemperature = R.string.nextSunnyDay.hyphen()
+            output.backgroundColor = Color(R.color.nextSunnyDayBackgroudColor() ?? .orange)
+            output.nextSunnyDay = Date(timeIntervalSince1970: Double(nearestSunnyDay.date)).format(text: "MM/dd (EEE)")
+            if let temp = nearestSunnyDay.temp {
+                output.maxTemperature = String("\(temp.max)℃")
+                output.minTemperature = String("\(temp.min)℃")
+            }
         }
 
         self.input = input

--- a/NextSunnyDay/ViewModel/NextSunnyDayViewModel.swift
+++ b/NextSunnyDay/ViewModel/NextSunnyDayViewModel.swift
@@ -63,13 +63,13 @@ class NextSunnyDayViewModel: NextSunnyDayViewModelObject {
         if let nearestSunnyDay = forecast.daily.filter({ sunnyCodes.contains($0.weather.first?.id ?? 0) }).min(by: { $0.date < $1.date }) {
             // UNIX -> Date
             let formatter = DateFormatter()
-            formatter.dateFormat = "yMMMdE"
+            formatter.dateFormat = "MM/ddE"
             let nextSunnyDay = formatter.string(from: Date(timeIntervalSince1970: Double(nearestSunnyDay.date)))
 
             output.cityName = forecast.cityName
             output.nextSunnyDay = nextSunnyDay
-            output.maxTemperature = String("\(nearestSunnyDay.temp?.max)")
-            output.minTemperature = String("\(nearestSunnyDay.temp?.min)")
+            output.maxTemperature = String("\(nearestSunnyDay.temp?.max)℃")
+            output.minTemperature = String("\(nearestSunnyDay.temp?.min)℃")
         } else {
             output.backgroundColor = Color(R.color.noSunnyDayBackgroundColor() ?? .gray)
             output.cityName = forecast.cityName


### PR DESCRIPTION
# Issue
close #13 

# 対応詳細
- smallサイズとmediumサイズの次に晴れる日Widgetの元となるView（`NextSunnyDayView`）を実装
- `NextSunnyDayView`のViewModel（NextSunnyDayViewModel）を実装
- `HomeView`に`NextSunnyDayView`を追加
    - `HomeViewModel`のoutputを修正
- その他微修正