### PR TITLE
Realmのバージョンを5.x.xに戻す

### DIFF
--- a/NextSunnyDay.xcodeproj/project.pbxproj
+++ b/NextSunnyDay.xcodeproj/project.pbxproj
@@ -861,7 +861,7 @@
 			repositoryURL = "https://github.com/realm/realm-cocoa";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 10.0.0;
+				minimumVersion = 5.5.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
# Issue
close #37 

# 対応詳細
- Realmを5.4.8から10.0.0にアップデート