### PR TITLE
GitHub ActionsのworkflowでMintとSwiftPMで管理しているライブラリのバイナリをキャッシュするように修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mint-
 
+      - name: Mint bootstrap
+        run: mint bootstrap
+
       - name: Cache Swift Package Manager packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,9 @@ env:
 jobs:
   build:
     runs-on: macOS-latest
+    env:
+      MINT_PATH: mint/lib
+      MINT_LINK_PATH: mint/bin
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,14 @@ jobs:
       - name: Mint bootstrap
         run: mint bootstrap
 
+      - name: Cache Swift Package Manager packages
+        uses: actions/cache@v2
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Inject Access Token
         run: echo "let OPEN_WEATHER_API_KEY = \"${{ secrets.OPEN_WEATHER_API_KEY }}\"" > ./NextSunnyDay/API/AccessTokens.swift
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,9 +35,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mint-
 
-      - name: Mint bootstrap
-        run: mint bootstrap
-
       - name: Cache Swift Package Manager packages
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
# Issue
close #67 

# 対応詳細
- GitHub ActionsのCIワークフローのbuildステップの`env`にMintで管理しているライブラリのバイナリをキャッシュするディレクトリを追加