### PR TITLE
天気情報更新時間を変更

### DIFF
--- a/NextSunnyDayWidget/NextSunnyDayWidget.swift
+++ b/NextSunnyDayWidget/NextSunnyDayWidget.swift
@@ -34,7 +34,7 @@ struct Provider: TimelineProvider {
         let timeline = Timeline(entries: [SimpleEntry(date: currentDate, entity: entity)], policy: .after(entryDate))
 
         let latestDate = entity.daily.min(by: { $0.date < $1.date })?.date ?? 0
-        if !entity.cityName.isEmpty && latestDate + 60 * 60 * 24 < Int(currentDate.timeIntervalSince1970) {
+        if !entity.cityName.isEmpty && latestDate + 60 * 60 * 20 < Int(currentDate.timeIntervalSince1970) {
             weatherFetcher.weeklyWeatherForecast(forLat: entity.lat, forLon: entity.lon)
                 .receive(on: RunLoop.main)
                 .sink(


### PR DESCRIPTION
# 概要
天気情報更新時間を最遅16時から最遅12時に変更した
（午後になっても最新のデータに更新されないのはよくなさそうと思ったため

# 対応内容
- [x] 天気情報更新時間を最遅16時から最遅12時に変更